### PR TITLE
Add Package Manager Basic Support

### DIFF
--- a/build/ci/kpm/Dockerfile
+++ b/build/ci/kpm/Dockerfile
@@ -1,0 +1,36 @@
+FROM  golang:1.20.1-alpine3.17 as  builder
+# builder-golang-alpine
+WORKDIR /app
+ENV GOPROXY https://goproxy.cn
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
+&& apk add --no-cache build-base \
+&& apk add --no-cache upx \
+&& apk add --no-cache git \
+&& mkdir /lib64 \
+&& ln -s /lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+# building kpm
+ARG COMPRESS='false'
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -trimpath -a -ldflags "-linkmode external -w -s -extldflags  -static " -gcflags "-l=4 -m=2 "  --tags netgo -o /dist/kpm github.com/KusionStack/kpm/cmd/kpm  \
+    &&  if [  ${COMPRESS} = 'true' ]; then upx -9 /dist/kpm; fi && ls /dist
+
+
+
+FROM alpine:3.17.2
+# runtime-env-alpine-git
+ENV TZ="Asia/Shanghai"
+WORKDIR /app
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
+&& apk add --no-cache tzdata \
+&& apk add --no-cache ca-certificates \
+&& apk add --no-cache git \
+&& mkdir /lib64 \
+&& ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
+&& ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
+&& echo $TZ > /etc/timezone \
+# add kpm and run it
+COPY  --from=builder  /dist/kpm /bin/kpm
+CMD ["/bin/sh"]
+

--- a/build/ci/kpm/Dockerfile
+++ b/build/ci/kpm/Dockerfile
@@ -19,7 +19,6 @@ RUN go build -trimpath -a -ldflags "-linkmode external -w -s -extldflags  -stati
 
 
 FROM alpine:3.17.2
-# runtime-env-alpine-git
 ENV TZ="Asia/Shanghai"
 WORKDIR /app
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
@@ -29,8 +28,7 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 && mkdir /lib64 \
 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
 && ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
-&& echo $TZ > /etc/timezone \
-# add kpm and run it
+&& echo $TZ > /etc/timezone
 COPY  --from=builder  /dist/kpm /bin/kpm
 CMD ["/bin/sh"]
 

--- a/cmd/kpm/main.go
+++ b/cmd/kpm/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/KusionStack/kpm/pkg/kpm"
+	"os"
+)
+
+func main() {
+	err := kpm.CLI(os.Args...)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,19 @@
+module github.com/KusionStack/kpm
+
+go 1.20
+
+require (
+	github.com/cespare/xxhash/v2 v2.1.2
+	github.com/urfave/cli/v2 v2.24.4
+	github.com/valyala/bytebufferpool v1.0.0
+	github.com/valyala/fasthttp v1.40.0
+
+)
+
+require (
+	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/klauspost/compress v1.15.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+)

--- a/pkg/go-oneutils/Convert/func.go
+++ b/pkg/go-oneutils/Convert/func.go
@@ -1,0 +1,19 @@
+package Convert
+
+import (
+	"unsafe"
+)
+
+const hextable = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// S2B string转[]byte
+func S2B(s string) (b []byte) {
+	*(*string)(unsafe.Pointer(&b)) = s
+	*(*int)(unsafe.Pointer(uintptr(unsafe.Pointer(&b)) + 2*unsafe.Sizeof(&b))) = len(s)
+	return
+}
+
+// B2S []byte转string
+func B2S(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/pkg/go-oneutils/ExecCmd/func.go
+++ b/pkg/go-oneutils/ExecCmd/func.go
@@ -1,0 +1,49 @@
+package ExecCmd
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+)
+
+// Run  运行命令
+func Run(dir string, name string, args ...string) error {
+	cmd := exec.Command(
+		name, args...)
+	cmd.Dir = dir
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+	err = cmd.Wait()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RunWithStdout 运行命令并取得成功返回值
+func RunWithStdout(dir string, name string, args ...string) (string, error) {
+	cmd := exec.Command(
+		name, args...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Start()
+	if err != nil {
+		return "", err
+	}
+	err = cmd.Wait()
+	if err != nil {
+		return "", err
+	}
+	outStr, errStr := stdout.String(), stderr.String()
+	if err != nil {
+		return "", err
+	}
+	if errStr != "" {
+		return "", errors.New(errStr)
+	}
+	return outStr, nil
+}

--- a/pkg/go-oneutils/Fetch/func.go
+++ b/pkg/go-oneutils/Fetch/func.go
@@ -1,0 +1,214 @@
+package Fetch
+
+import (
+	"encoding/json"
+	"github.com/valyala/fasthttp"
+	"sync"
+)
+
+type EasyJsonSerialization interface {
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON(data []byte) error
+}
+type Client struct {
+	proxy   string
+	options []Option
+}
+
+func NewClient(proxy string, options ...Option) *Client {
+	return &Client{
+		proxy:   proxy,
+		options: options,
+	}
+}
+
+type Ctx struct {
+	req  *fasthttp.Request
+	resp *fasthttp.Response
+}
+
+var ctxpool = sync.Pool{New: func() any {
+	return &Ctx{
+		req:  fasthttp.AcquireRequest(),
+		resp: fasthttp.AcquireResponse(),
+	}
+}}
+
+func AcquireCtx() *Ctx {
+	return ctxpool.Get().(*Ctx)
+}
+func ReleaseRequest(ctx *Ctx) {
+	ctx.Reset()
+	ctxpool.Put(ctx)
+}
+func (c *Ctx) Reset() {
+	c.req.Reset()
+	c.resp.Reset()
+}
+
+func (c *Client) Json(ctx *Ctx, endpoint string, reqData any, respData any, options ...Option) error {
+	ctx.Reset()
+	ctx.req.Header.SetMethod("POST")
+	ctx.req.SetRequestURI(endpoint)
+	if reqData != nil {
+		jsonbytes, err := json.Marshal(reqData)
+		if err != nil {
+			return err
+		}
+		ctx.req.SetBody(jsonbytes)
+	}
+	if c.proxy != "" {
+		ctx.req.Header.SetHostBytes(ctx.req.URI().Host())
+		ctx.req.URI().SetHost(c.proxy)
+	}
+	for i := 0; i < len(c.options); i++ {
+		options[i](ctx.req)
+	}
+	for i := 0; i < len(options); i++ {
+		options[i](ctx.req)
+	}
+	if err := fasthttp.Do(ctx.req, ctx.resp); err != nil {
+		return err
+	}
+	body, err := ctx.resp.BodyUncompressed()
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(body, respData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type Option func(req *fasthttp.Request)
+
+// UseGetOption 设置GET请求
+func UseGetOption(req *fasthttp.Request) {
+	req.Header.SetMethod("GET")
+}
+
+// UseCompressOption 设置请求优先使用压缩
+func UseCompressOption(req *fasthttp.Request) {
+	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+}
+
+// SetHostHeadOption 设置host头
+func SetHostHeadOption(req *fasthttp.Request) {
+	req.Header.SetHostBytes(req.URI().Host())
+}
+
+// SetCustomHostHeadOption  设置用户自定义host头
+func SetCustomHostHeadOption(host string) Option {
+	return func(req *fasthttp.Request) {
+		req.Header.SetHost(host)
+	}
+}
+
+// Json  json请求与响应
+func Json(endpoint string, reqData any, respData any, options ...Option) error {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.Header.SetMethod("POST")
+	req.SetRequestURI(endpoint)
+	if reqData != nil {
+		jsonbytes, err := json.Marshal(reqData)
+		if err != nil {
+			return err
+		}
+		req.SetBody(jsonbytes)
+	}
+	for i := 0; i < len(options); i++ {
+		options[i](req)
+	}
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	if err := fasthttp.Do(req, resp); err != nil {
+		return err
+	}
+	body, err := resp.BodyUncompressed()
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(body, respData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Text text请求与响应
+func Text(endpoint string, reqData string, options ...Option) (string, error) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.Header.SetMethod("POST")
+	req.SetRequestURI(endpoint)
+	req.SetBodyString(reqData)
+	for i := 0; i < len(options); i++ {
+		options[i](req)
+	}
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	if err := fasthttp.Do(req, resp); err != nil {
+		return "", err
+	}
+	body, err := resp.BodyUncompressed()
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// Query 查询请求与响应
+func Query(endpoint string, reqData *fasthttp.Args, options ...Option) (string, error) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.Header.SetMethod("GET")
+	req.SetRequestURI(endpoint)
+	if reqData != nil {
+		reqData.CopyTo(req.URI().QueryArgs())
+	}
+	for i := 0; i < len(options); i++ {
+		options[i](req)
+	}
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	if err := fasthttp.Do(req, resp); err != nil {
+		return "", err
+	}
+	body, err := resp.BodyUncompressed()
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// EasyJson 使用easyJson接口的json请求与响应
+func EasyJson(endpoint string, reqData EasyJsonSerialization, respData EasyJsonSerialization, options ...Option) error {
+	jsonbytes, err := reqData.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.Header.SetMethod("POST")
+	req.SetRequestURI(endpoint)
+	req.SetBody(jsonbytes)
+	for i := 0; i < len(options); i++ {
+		options[i](req)
+	}
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	if err = fasthttp.Do(req, resp); err != nil {
+		return err
+	}
+	body, err := resp.BodyUncompressed()
+	if err != nil {
+		return err
+	}
+	err = respData.UnmarshalJSON(body)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/go-oneutils/GlobalStore/FileInfoMap.go
+++ b/pkg/go-oneutils/GlobalStore/FileInfoMap.go
@@ -1,0 +1,82 @@
+package GlobalStore
+
+import (
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Convert"
+	"sort"
+)
+
+// FileInfoMap 文件相对路径 文件信息
+type FileInfoMap map[string]*FileInfo
+
+// Equal 检测两个FileInfoMap是否相等
+func (m FileInfoMap) Equal(fim FileInfoMap) bool {
+	if len(m) != len(fim) {
+		return false
+	}
+	for k, info := range m {
+		fileInfo, ok := fim[k]
+		if !ok {
+			return false
+		}
+		if info.Integrity != fileInfo.Integrity {
+			return false
+		}
+		if info.Size != fileInfo.Size {
+			return false
+		}
+		if info.Mode != fileInfo.Mode {
+			return false
+		}
+		if info.CheckedAt != fileInfo.CheckedAt {
+			return false
+		}
+	}
+	return true
+}
+
+// FileEqual 仅检测两个FileInfoMap的文件是否相等
+func (m FileInfoMap) FileEqual(fim FileInfoMap) bool {
+	if len(m) != len(fim) {
+		return false
+	}
+	for k, info := range m {
+		fileInfo, ok := fim[k]
+		if !ok {
+			return false
+		}
+		if info.Integrity != fileInfo.Integrity {
+			return false
+		}
+		if info.Size != fileInfo.Size {
+			return false
+		}
+
+	}
+	return true
+}
+
+// GetIntegrity 生成这个FileInfoMap唯一的Integrity
+func (m FileInfoMap) GetIntegrity() Integrity {
+	t := "sha512"
+	var sumlists = make([]string, len(m))
+	for s, info := range m {
+		value, err := info.Integrity.GetRawHashValue()
+		if err != nil {
+			return ""
+		}
+		t = info.Integrity.GetType()
+		nameit := NewIntegrity(t, []byte(s))
+		hashValue, err := nameit.GetRawHashValue()
+		if err != nil {
+			return ""
+		}
+		hashValue = append(hashValue, value...)
+		sumlists = append(sumlists, Convert.B2S(hashValue))
+	}
+	sort.Strings(sumlists)
+	var sumstr string
+	for i := 0; i < len(sumlists); i++ {
+		sumstr += sumlists[i]
+	}
+	return NewIntegrity(t, Convert.S2B(sumstr))
+}

--- a/pkg/go-oneutils/GlobalStore/FileInfoMapPool.go
+++ b/pkg/go-oneutils/GlobalStore/FileInfoMapPool.go
@@ -1,0 +1,24 @@
+package GlobalStore
+
+import "sync"
+
+var poolFileInfoMap = sync.Pool{
+	New: func() any {
+		return make(FileInfoMap, 16)
+	},
+}
+
+func (m FileInfoMap) Reset() {
+	for k, v := range m {
+		ReleaseFileInfo(v)
+		delete(m, k)
+	}
+}
+func AcquireFileInfoMap() FileInfoMap {
+	return poolFileInfoMap.Get().(FileInfoMap)
+}
+
+func ReleaseFileInfoMap(m FileInfoMap) {
+	m.Reset()
+	poolFileInfoMap.Put(m)
+}

--- a/pkg/go-oneutils/GlobalStore/FileInfoPool.go
+++ b/pkg/go-oneutils/GlobalStore/FileInfoPool.go
@@ -1,0 +1,24 @@
+package GlobalStore
+
+import "sync"
+
+var poolFileInfo = sync.Pool{
+	New: func() any {
+		return &FileInfo{}
+	},
+}
+
+func (fi *FileInfo) Reset() {
+	fi.CheckedAt = 0
+	fi.Mode = 0
+	fi.Size = 0
+	fi.Integrity = EmptyString
+}
+func AcquireFileInfo() *FileInfo {
+	return poolFileInfo.Get().(*FileInfo)
+}
+
+func ReleaseFileInfo(fi *FileInfo) {
+	fi.Reset()
+	poolFileInfo.Put(fi)
+}

--- a/pkg/go-oneutils/GlobalStore/FileStore.go
+++ b/pkg/go-oneutils/GlobalStore/FileStore.go
@@ -1,0 +1,435 @@
+package GlobalStore
+
+import (
+	"errors"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Fetch"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/PathHandle"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const Separator = string(filepath.Separator)
+const EmptyString = ""
+const (
+	hashStrMod = iota
+	hashStrPrefix
+)
+
+type FileStore struct {
+	//工作根目录
+	root string
+	//元数据目录（在根目录下的相对目录）
+	metadata string
+	//构建目录
+	build string
+	//存储目录
+	store string
+	//桶数量，建议为16的次方
+	bucketCount int
+	//桶数量指数，16的指数次方
+	bucketCountIndexNumber int
+	//桶分配方式 hashStrMod hashStrPrefix
+	bucketAllocationMethod int
+	//hash算法 建议sha512
+	bucketHashType string
+	//忽略规则方法
+	ignoreFunc []IgnoreFunc
+}
+type FileStoreConfig struct {
+	//工作根目录
+	Root string
+	//元数据目录（在根目录下的相对目录）
+	Metadata string
+	//构建目录（在根目录下的相对目录）
+	Build string
+	//存储目录（在根目录下的相对目录）
+	Store string
+	//桶数量指数，16的指数次方
+	BucketCountIndexNumber int
+	//桶分配方式 hashStrMod,hashStrPrefix
+	BucketAllocationMethod string
+	//hash算法 建议sha512
+	BucketHashType string
+}
+
+// IgnoreFunc 忽略文件的规则 返回真为忽略
+type IgnoreFunc func(relPath string, info os.FileInfo) bool
+
+func IgnoreDotGitPath(relPath string, info os.FileInfo) bool {
+	if strings.HasPrefix(relPath, ".git"+Separator) {
+		return true
+	}
+	return false
+}
+func IgnoreDotExternalPath(relPath string, info os.FileInfo) bool {
+	if strings.HasPrefix(relPath, "external"+Separator) {
+		return true
+	}
+	return false
+}
+
+type FileInfo struct {
+	//日期
+	CheckedAt int64 `json:"checked_at"`
+	//完整性校验
+	Integrity Integrity `json:"integrity"`
+	//权限
+	Mode int `json:"mode"`
+	//文件大小
+	Size int64 `json:"size"`
+}
+
+type Metadata interface {
+	GetFileInfoMap() FileInfoMap
+	SetFileInfoMap(fim FileInfoMap)
+	Fetch.EasyJsonSerialization
+}
+
+// NewFileStore 初始化文件存储
+func NewFileStore(cfg FileStoreConfig, ignoreFunc ...IgnoreFunc) (*FileStore, error) {
+	f := FileStore{
+		root:       cfg.Root,
+		metadata:   cfg.Root + Separator + "metadata",
+		build:      cfg.Root + Separator + "build",
+		store:      cfg.Root + Separator + "store",
+		ignoreFunc: ignoreFunc,
+	}
+	if cfg.Metadata != "" {
+		f.metadata = cfg.Root + Separator + cfg.Metadata
+	}
+	if cfg.Build != "" {
+		f.build = cfg.Root + Separator + cfg.Build
+	}
+	if cfg.Store != "" {
+		f.store = cfg.Root + Separator + cfg.Store
+	}
+	err := PathHandle.KeepDirsExist(
+		f.root,
+		f.metadata,
+		f.build,
+		f.store,
+	)
+	if err != nil {
+		return nil, nil
+	}
+	switch cfg.BucketCountIndexNumber {
+	case 3:
+		f.bucketCount = 4096
+		f.bucketCountIndexNumber = 3
+	default:
+		f.bucketCount = 256
+		f.bucketCountIndexNumber = 2
+	}
+	switch cfg.BucketAllocationMethod {
+	case "hashStrPrefix":
+		f.bucketAllocationMethod = hashStrPrefix
+	default:
+		//hashStrMod
+		f.bucketAllocationMethod = hashStrMod
+	}
+	switch cfg.BucketHashType {
+	case "md5":
+		f.bucketHashType = "md5"
+	case "sha1":
+		f.bucketHashType = "sha1"
+	case "sha256":
+		f.bucketHashType = "sha256"
+	default:
+		//case "sha512":
+		f.bucketHashType = "sha512"
+	}
+	return &f, nil
+}
+
+// contains  判断path1是否包含path2
+func contains(path1, path2 string) bool {
+	if strings.HasPrefix(path1, path2) {
+		return true
+	}
+	tmp, tmp2 := strings.Split(path2, Separator), ""
+	for i := 0; i < len(tmp); i++ {
+		tmp2 += tmp[i]
+		//判断是否相等
+		if tmp2 == path1 {
+			return true
+		}
+		tmp2 += Separator
+	}
+	return false
+}
+
+// AddDir 添加目录到全局文件存储
+func (s FileStore) AddDir(absPath string) (FileInfoMap, error) {
+	//路径不应该为root目录的父目录，及不应该为相对路径
+	if !filepath.IsAbs(absPath) {
+		return nil, errors.New("the path is not absolute")
+	}
+	if contains(absPath, s.store) {
+		return nil, errors.New("absPath cannot contain store root directory")
+	}
+	fim := AcquireFileInfoMap()
+	err := filepath.Walk(absPath,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			//获取相对路径到结构体切片
+			if info.IsDir() {
+				//跳过文件夹
+				return nil
+			}
+			rel, err := filepath.Rel(absPath, path)
+			if err != nil {
+				return err
+			}
+			for i := 0; i < len(s.ignoreFunc); i++ {
+				if s.ignoreFunc[i](rel, info) {
+					return nil
+				}
+			}
+			file, err2 := os.ReadFile(path)
+			if err2 != nil {
+				return err2
+			}
+
+			rp := []byte(rel)
+			//统一为Linux下的分隔符
+			PathHandle.UnifyPathSlashSeparator(rp)
+			//添加文件信息
+			it := NewIntegrity(s.bucketHashType, file)
+			afi := AcquireFileInfo()
+			afi.CheckedAt = info.ModTime().Unix()
+			afi.Integrity = it
+			afi.Mode = int(info.Mode())
+			afi.Size = info.Size()
+			fim[string(rp)] = afi
+			switch s.bucketAllocationMethod {
+			case hashStrPrefix:
+
+				hashString, err := it.GetRawHashString()
+				if err != nil {
+					return err
+				}
+				//println(hashString, hashString[:2], hashString[2:])
+				bucketpath := s.store + Separator + hashString[:s.bucketCountIndexNumber]
+				err = PathHandle.KeepDirExist(bucketpath)
+				if err != nil {
+					return err
+				}
+				err = os.WriteFile(bucketpath+Separator+hashString[s.bucketCountIndexNumber:], file, 0777)
+				if err != nil {
+					return err
+				}
+
+			default:
+				//case :"hashStrMod"
+
+				//添加文件到全局存储桶
+				rawhashstring, mod, err := it.GetRawHashStringAndModFast(uint64(s.bucketCount))
+				if err != nil {
+					return err
+				}
+				bucketpath := s.store + Separator + mod
+				err = PathHandle.KeepDirExist(bucketpath)
+				if err != nil {
+					return err
+				}
+				err = os.WriteFile(bucketpath+Separator+rawhashstring, file, 0777)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return fim, nil
+}
+
+// NewFileInfoMapFromDir 仅从文件夹生成FileInfoMap
+func (s FileStore) NewFileInfoMapFromDir(absPath string) (FileInfoMap, error) {
+	//路径不应该为root目录
+	if !filepath.IsAbs(absPath) {
+		return nil, errors.New("the path is not absolute")
+	}
+	if contains(absPath, s.store) {
+		return nil, errors.New("absPath cannot contain store root directory")
+	}
+	fim := AcquireFileInfoMap()
+	err := filepath.Walk(absPath,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			//获取相对路径到结构体切片
+			if info.IsDir() {
+				//跳过文件夹
+				return nil
+			}
+			rel, err := filepath.Rel(absPath, path)
+			if err != nil {
+				return err
+			}
+			for i := 0; i < len(s.ignoreFunc); i++ {
+				if s.ignoreFunc[i](rel, info) {
+					return nil
+				}
+			}
+			file, err2 := os.ReadFile(path)
+			if err2 != nil {
+				return err2
+			}
+
+			rp := []byte(rel)
+			//统一为Linux下的分隔符
+			PathHandle.UnifyPathSlashSeparator(rp)
+			//添加文件信息
+			afi := AcquireFileInfo()
+			afi.CheckedAt = info.ModTime().Unix()
+			afi.Integrity = NewIntegrity(s.bucketHashType, file)
+			afi.Mode = int(info.Mode())
+			afi.Size = info.Size()
+			fim[string(rp)] = afi
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return fim, nil
+}
+
+// BuildDir 通过FileInfoMap构建包目录在工作区构建目录下
+func (s FileStore) BuildDir(fim FileInfoMap, pkgDir string) error {
+	//构建目录
+	buildpath := s.build + Separator + PathHandle.URLToLocalDirPath(pkgDir)
+	exists, err := PathHandle.DirExist(buildpath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return errors.New("path exist")
+	}
+	err = os.MkdirAll(buildpath, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	for s2, info := range fim {
+		d, _ := filepath.Split(s2)
+		if d != "" {
+			err = PathHandle.KeepDirExist(buildpath + Separator + d)
+			if err != nil {
+				err = os.RemoveAll(buildpath)
+				if err != nil {
+					return err
+				}
+				return err
+			}
+		}
+		switch s.bucketAllocationMethod {
+		case hashStrPrefix:
+			hashString, err := info.Integrity.GetRawHashString()
+			if err != nil {
+				err = os.RemoveAll(buildpath)
+				if err != nil {
+					return err
+				}
+				return err
+			}
+			hashpath := s.store + Separator + hashString[:s.bucketCountIndexNumber] + Separator + hashString[s.bucketCountIndexNumber:]
+			err = os.Link(hashpath, buildpath+Separator+s2)
+			if err != nil {
+				err = os.RemoveAll(buildpath)
+				if err != nil {
+					return err
+				}
+				return err
+			}
+		default:
+			//case :"hashStrMod"
+			hashString, mod, err := info.Integrity.GetRawHashStringAndModFast(uint64(s.bucketCount))
+			if err != nil {
+				err = os.RemoveAll(buildpath)
+				if err != nil {
+					return err
+				}
+				return err
+			}
+			hashpath := s.store + Separator + mod + Separator + hashString
+			err = os.Link(hashpath, buildpath+Separator+s2)
+			if err != nil {
+				err = os.RemoveAll(buildpath)
+				if err != nil {
+					return err
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Link 链接包目录到目标目录
+func (s FileStore) Link(pkgDir, targetAbsPath string) error {
+	if !filepath.IsAbs(targetAbsPath) {
+		return errors.New("the path is not absolute")
+	}
+	var tmp string
+	for i := len(targetAbsPath) - 1; i >= 0; i-- {
+		if targetAbsPath[i] == filepath.Separator {
+			tmp = targetAbsPath[:i]
+			break
+		}
+	}
+	err := PathHandle.KeepDirExist(tmp)
+	if err != nil {
+		return err
+	}
+	err = os.Symlink(s.build+Separator+PathHandle.URLToLocalDirPath(pkgDir), targetAbsPath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// VerifyDir 验证文件目录
+func (s FileStore) VerifyDir(fim FileInfoMap, absPath string) (bool, error) {
+	if !filepath.IsAbs(absPath) {
+		return false, errors.New("the path is not absolute")
+	}
+	nfim, err := s.NewFileInfoMapFromDir(absPath)
+	if err != nil {
+		return false, err
+	}
+	result := fim.FileEqual(nfim)
+	ReleaseFileInfoMap(nfim)
+	return result, nil
+}
+
+// GetMetadataPath 获取metadata的理论绝对路径
+func (s FileStore) GetMetadataPath(pkgDir string) (string, error) {
+	p := s.metadata + Separator + PathHandle.URLToLocalDirPath(pkgDir)
+	dir, _ := filepath.Split(p)
+	err := PathHandle.KeepDirExist(dir)
+	if err != nil {
+		return "", err
+	}
+	return p, nil
+}
+
+// GetDirPath 获取pkgDir的理论绝对路径
+func (s FileStore) GetDirPath(pkgDir string) (string, error) {
+	p := s.build + Separator + PathHandle.URLToLocalDirPath(pkgDir)
+	dir, _ := filepath.Split(p)
+	err := PathHandle.KeepDirExist(dir)
+	if err != nil {
+		return "", err
+	}
+	return p, nil
+}
+
+// DirIsExist 检测pkgDir存在
+func (s FileStore) DirIsExist(pkgDir string) (bool, error) {
+	return PathHandle.DirExist(s.build + Separator + PathHandle.URLToLocalDirPath(pkgDir))
+}

--- a/pkg/go-oneutils/GlobalStore/Integrity.go
+++ b/pkg/go-oneutils/GlobalStore/Integrity.go
@@ -1,0 +1,105 @@
+package GlobalStore
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"github.com/cespare/xxhash/v2"
+)
+
+const hextable = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+type Integrity string
+
+// GetType 获取hash类型
+func (it Integrity) GetType() string {
+	for i := 0; i < len(it); i++ {
+		if it[i] == '-' {
+			return string(it[:i])
+		}
+	}
+	return ""
+}
+
+// GetValue 获取直接来自Integrity的值（hash+base64计算得到）
+func (it Integrity) GetValue() string {
+	itlen := len(it)
+	for i := 0; i < itlen; i++ {
+		if it[i] == '-' {
+			if itlen > i+1 {
+				return string(it[i+1:])
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+// GetRawHashValue 获取原始hash值
+func (it Integrity) GetRawHashValue() ([]byte, error) {
+	decodeString, err := base64.StdEncoding.DecodeString(it.GetValue())
+	if err != nil {
+		return nil, err
+	}
+	return decodeString, nil
+}
+
+// GetRawHashString 获取原始hash字符串值 hash to string
+func (it Integrity) GetRawHashString() (string, error) {
+	value, err := it.GetRawHashValue()
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}
+func (it Integrity) GetRawHashStringAndMod256() (string, string, error) {
+	hashRawValue, err := it.GetRawHashValue()
+	if err != nil {
+		return "", "", err
+	}
+	t := xxhash.Sum64(hashRawValue) & 255
+	return hex.EncodeToString(hashRawValue), string([]byte{hextable[t>>4], hextable[t&15]}), nil
+}
+func (it Integrity) GetRawHashStringAndMod(i uint64) (string, string, error) {
+	hashRawValue, err := it.GetRawHashValue()
+	if err != nil {
+		return "", "", err
+	}
+	t := xxhash.Sum64(hashRawValue) % i
+	return hex.EncodeToString(hashRawValue), string([]byte{hextable[t>>4], hextable[t&15]}), nil
+}
+
+// GetRawHashStringAndModFast 获取原始hash字符串并且快速取模（i为16的n次方）
+func (it Integrity) GetRawHashStringAndModFast(i uint64) (string, string, error) {
+	hashRawValue, err := it.GetRawHashValue()
+	if err != nil {
+		return "", "", err
+	}
+	t := xxhash.Sum64(hashRawValue) & (i - 1)
+	return hex.EncodeToString(hashRawValue), string([]byte{hextable[t>>4], hextable[t&15]}), nil
+}
+
+// NewIntegrity 新建Integrity实例
+func NewIntegrity(integrityType string, data []byte) Integrity {
+	var integrityBytes = make([]byte, 64)
+	integrityBytes = integrityBytes[:0]
+	switch integrityType {
+	case "md5":
+		t := md5.Sum(data)
+		integrityBytes = append(integrityBytes, t[:]...)
+	case "sha1":
+		t := sha1.Sum(data)
+		integrityBytes = append(integrityBytes, t[:]...)
+	case "sha256":
+		t := sha256.Sum256(data)
+		integrityBytes = append(integrityBytes, t[:]...)
+	case "sha512":
+		t := sha512.Sum512(data)
+		integrityBytes = append(integrityBytes, t[:]...)
+	}
+
+	return Integrity(integrityType + "-" + base64.StdEncoding.EncodeToString(integrityBytes))
+}

--- a/pkg/go-oneutils/PathHandle/func.go
+++ b/pkg/go-oneutils/PathHandle/func.go
@@ -1,0 +1,202 @@
+package PathHandle
+
+import (
+	"crypto/sha512"
+	"errors"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Convert"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Random"
+	"github.com/cespare/xxhash/v2"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const Separator = string(filepath.Separator)
+const hextable = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// RunInTempDir 在缓存目录中工作
+func RunInTempDir(f func(tmppath string) error) error {
+	p := os.TempDir() + Separator + Convert.B2S(Random.RandBytes32())
+	err := KeepDirExist(p)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(p)
+
+	err = f(p)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnifyPathSlashSeparator 统一路径分隔符为斜杠
+func UnifyPathSlashSeparator(b []byte) {
+	for i := 0; i < len(b); i++ {
+		if b[i] == '\\' {
+			b[i] = '/'
+		}
+	}
+}
+
+// UnifyPathBackSlashSeparator 统一路径分隔符为反斜杠
+func UnifyPathBackSlashSeparator(b []byte) {
+	for i := 0; i < len(b); i++ {
+		if b[i] == '/' {
+			b[i] = '\\'
+		}
+	}
+}
+
+// UnifyPathBackLocalSeparator 统一路径分隔符为当前系统斜杠
+func UnifyPathBackLocalSeparator(b []byte) {
+	for i := 0; i < len(b); i++ {
+		if b[i] == '/' || b[i] == '\\' {
+			b[i] = filepath.Separator
+		}
+	}
+}
+
+// Bucket256AllocatedUseSha512  使用sha512作为hash算法为文件分配桶（256个桶下）
+//
+//	mod取自hash转换为可见字符串之后的值
+//	 已优化 可以被内联
+func Bucket256AllocatedUseSha512(fileBytes []byte) (hash string, mod string) {
+	sha512hash, dst, j := sha512.Sum512(fileBytes), make([]byte, 128), 0
+	//转为可见字符
+	for _, v := range sha512hash {
+		dst[j], dst[j+1] = hextable[v>>4], hextable[v&0x0f]
+		j += 2
+	}
+	//
+	t, hash := xxhash.Sum64(dst)%256, string(dst)
+	mod = string([]byte{hextable[t>>4], hextable[t%16]})
+	return
+}
+
+// KeepDirsExist  确保某些目录一定存在
+func KeepDirsExist(paths ...string) error {
+	for i := 0; i < len(paths); i++ {
+		err := KeepDirExist(paths[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// KeepDirExist 确保某目录一定存在
+func KeepDirExist(path string) error {
+	f, err := os.Stat(path)
+	if err == nil {
+		//存在
+		if f.IsDir() {
+			//是已经存在的目录 不处理
+			return nil
+		}
+		//是文件,返回错误
+		return errors.New("file exists instead of directory")
+	}
+	if os.IsNotExist(err) {
+
+		//不存在
+		err = os.MkdirAll(path, os.ModePerm)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	//其他错误
+	return err
+}
+
+// URLToLocalDirPath uri转本地相对路径
+func URLToLocalDirPath(url string) string {
+	tmp := strings.Split(url, "://")
+	tmplen := len(tmp)
+	var tmpbytes []byte
+	if tmplen == 2 {
+		tmpbytes = append(tmpbytes, tmp[1]...)
+
+	} else {
+		tmpbytes = append(tmpbytes, tmp[0]...)
+	}
+	for i := 0; i < len(tmpbytes); i++ {
+		if tmpbytes[i] == '/' {
+			tmpbytes[i] = filepath.Separator
+		}
+	}
+	return string(tmpbytes)
+}
+
+// URLToLocalDirPathNoHost  uri转本地相对路径不带域名
+func URLToLocalDirPathNoHost(url string) string {
+	tmp := strings.Split(url, "://")
+	tmplen := len(tmp)
+	var tmpbytes []byte
+	if tmplen == 2 {
+		tmpbytes = append(tmpbytes, tmp[1]...)
+
+	} else {
+		tmpbytes = append(tmpbytes, tmp[0]...)
+	}
+	hostflag := 0
+	hostindex := 0
+	for i := 0; i < len(tmpbytes); i++ {
+		if tmpbytes[i] == '/' {
+			hostflag++
+			if hostflag == 1 {
+				hostindex = i
+			}
+			tmpbytes[i] = filepath.Separator
+
+		}
+	}
+	if hostflag == 0 {
+		return ""
+	}
+	return string(tmpbytes[hostindex:])
+}
+
+// PathExist 路径是否存在
+func PathExist(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// FileExist  文件是否存在
+func FileExist(path string) (bool, error) {
+	f, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if f.IsDir() {
+		return false, errors.New("it is a Dir")
+	}
+	return true, nil
+}
+
+// DirExist 目录是否存在
+func DirExist(path string) (bool, error) {
+	f, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !f.IsDir() {
+		return false, errors.New("it is a File")
+	}
+	return true, nil
+}

--- a/pkg/go-oneutils/Random/func.go
+++ b/pkg/go-oneutils/Random/func.go
@@ -1,0 +1,48 @@
+package Random
+
+const hextable = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const hextable64 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01"
+
+// RandBytes 快速生成n位随机字节
+func RandBytes(n int) []byte {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = hextable64[RandInt64()]
+	}
+	return b
+}
+
+// RandBytes32 快速生成32位随机字节
+func RandBytes32() []byte {
+	b := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		b[i] = hextable64[RandInt64()]
+	}
+	return b
+}
+
+// RandIntn  快速生成num范围内的随机数
+func RandIntn(num uint32) uint32 {
+	return FastRand() % num
+}
+
+// RandInt64 快速生成64内的随机数 0-63
+func RandInt64() uint32 {
+	i := FastRand() & 63
+	return i
+}
+func RandInt36() uint32 {
+	return FastRand() & 35
+}
+
+// UUIDv4 快速生成UUIDv4
+func UUIDv4() []byte {
+	b := make([]byte, 36)
+	for i := 0; i < 30; i++ {
+		b[i] = hextable[FastRand()&35]
+	}
+	b[30], b[31], b[32], b[33], b[34], b[35],
+		b[8], b[13], b[14], b[18], b[19], b[23] = b[8], b[13], b[14], b[18], b[19], b[23],
+		'-', '-', '4', '-', 'a', '-'
+	return b
+}

--- a/pkg/go-oneutils/Random/link.go
+++ b/pkg/go-oneutils/Random/link.go
@@ -1,0 +1,6 @@
+package Random
+
+import _ "unsafe"
+
+//go:linkname FastRand runtime.fastrand
+func FastRand() uint32

--- a/pkg/go-oneutils/Semver/version.go
+++ b/pkg/go-oneutils/Semver/version.go
@@ -1,0 +1,280 @@
+package Semver
+
+import (
+	"errors"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Convert"
+	"strconv"
+)
+
+type VersionString string
+type Version struct {
+	Major           int    `json:"major"`
+	Minor           int    `json:"minor"`
+	Patch           int    `json:"patch"`
+	PreRelease      int    `json:"pre_release"`
+	PreReleaseCount int    `json:"pre_release_count"`
+	BuildMetadata   string `json:"build_metadata"`
+}
+
+const (
+	Alpha = iota
+	Beta
+	RC
+	Release
+)
+
+var PreReleaseNames = []string{"alpha", "beta", "rc", "release"}
+
+// 语义化版本号string
+func (v *Version) String() string {
+	vs := make([]byte, 64)
+	vs = vs[:0]
+	vs = append(vs, strconv.Itoa(v.Major)...)
+	vs = append(vs, '.')
+	vs = append(vs, strconv.Itoa(v.Minor)...)
+	vs = append(vs, '.')
+	vs = append(vs, strconv.Itoa(v.Patch)...)
+	if v.PreRelease != Release {
+		vs = append(vs, '-')
+		vs = append(vs, PreReleaseNames[v.PreRelease]...)
+		if v.PreReleaseCount != 0 {
+			vs = append(vs, '.')
+			vs = append(vs, strconv.Itoa(v.PreReleaseCount)...)
+		}
+	}
+	if v.BuildMetadata != "" {
+		vs = append(vs, '+')
+		vs = append(vs, v.BuildMetadata...)
+	}
+	return string(vs)
+}
+
+// TagString 语义化版本标签
+func (v *Version) TagString() string {
+	vs := make([]byte, 64)
+	vs = vs[:0]
+	vs = append(vs, 'v')
+	vs = append(vs, strconv.Itoa(v.Major)...)
+	vs = append(vs, '.')
+	vs = append(vs, strconv.Itoa(v.Minor)...)
+	vs = append(vs, '.')
+	vs = append(vs, strconv.Itoa(v.Patch)...)
+	if v.PreRelease != Release {
+		vs = append(vs, '-')
+		vs = append(vs, PreReleaseNames[v.PreRelease]...)
+		if v.PreReleaseCount != 0 {
+			vs = append(vs, '.')
+			vs = append(vs, strconv.Itoa(v.PreReleaseCount)...)
+		}
+	}
+	if v.BuildMetadata != "" {
+		vs = append(vs, '+')
+		vs = append(vs, v.BuildMetadata...)
+	}
+	return string(vs)
+}
+func NewFromString(str string) (*Version, error) {
+	v := Version{}
+	tmp := make([]byte, 8)
+	tmp = tmp[:0]
+	status := 0
+	v.PreRelease = 3
+
+	for i := 0; i < len(str); i++ {
+		s := str[i]
+		switch status {
+		case 0:
+			if s == 'v' || s == 'V' {
+				continue
+			} else {
+				if !isNum(s) {
+
+					return nil, errors.New("faulty data")
+				}
+			}
+			status++
+			fallthrough
+		case 1:
+			if isNum(s) {
+				tmp = append(tmp, s)
+			} else {
+				if s == '.' {
+					atoi, err := strconv.Atoi(Convert.B2S(tmp))
+					if err != nil {
+						return nil, err
+					}
+					v.Major = atoi
+					tmp = tmp[:0]
+					status++
+				} else {
+					return nil, errors.New("faulty data")
+				}
+			}
+		case 2:
+			if isNum(s) {
+				tmp = append(tmp, s)
+			} else {
+				if s == '.' {
+					atoi, err := strconv.Atoi(Convert.B2S(tmp))
+					if err != nil {
+						return nil, err
+					}
+					v.Minor = atoi
+					tmp = tmp[:0]
+					status++
+				} else {
+					return nil, errors.New("faulty data")
+				}
+			}
+		case 3:
+			if isNum(s) {
+				tmp = append(tmp, s)
+			} else {
+				if s == '-' {
+					atoi, err := strconv.Atoi(Convert.B2S(tmp))
+					if err != nil {
+						return nil, err
+					}
+					v.Patch = atoi
+					tmp = tmp[:0]
+					status++
+				} else if s == '+' {
+					atoi, err := strconv.Atoi(Convert.B2S(tmp))
+					if err != nil {
+						return nil, err
+					}
+					v.Patch = atoi
+					tmp = tmp[:0]
+					status += 3
+				} else {
+					return nil, errors.New("faulty data")
+				}
+			}
+		case 4:
+			//处理先行版字段
+			if s != '.' && s != '+' {
+				tmp = append(tmp, s)
+			} else {
+				//println(Convert.B2S(tmp))
+				for k := 0; k < len(tmp); k++ {
+					tembyte := tmp[k]
+					if tembyte >= 'A' && tembyte <= 'Z' {
+						tmp[k] += 32
+					}
+				}
+				for j := 0; j < len(PreReleaseNames); j++ {
+					if PreReleaseNames[j] == Convert.B2S(tmp) {
+						v.PreRelease = j
+						break
+					} else if j == len(PreReleaseNames)-1 {
+						return nil, errors.New("faulty data")
+					}
+				}
+				tmp = tmp[:0]
+				status++
+				if s == '+' {
+					status++
+				}
+			}
+		case 5:
+			//处理先行版版本号
+			if isNum(s) {
+				tmp = append(tmp, s)
+			} else {
+				if s == '+' {
+					atoi, err := strconv.Atoi(Convert.B2S(tmp))
+					if err != nil {
+						return nil, err
+					}
+					v.PreReleaseCount = atoi
+					tmp = tmp[:0]
+					status++
+				} else {
+					return nil, errors.New("faulty data")
+				}
+			}
+		case 6:
+			//编译元信息
+			tmp = append(tmp, s)
+		}
+	}
+
+	switch status {
+	case 3:
+		atoi, err := strconv.Atoi(Convert.B2S(tmp))
+		if err != nil {
+			return nil, err
+		}
+		v.Patch = atoi
+	case 4:
+		for k := 0; k < len(tmp); k++ {
+			tembyte := tmp[k]
+			if tembyte >= 'A' && tembyte <= 'Z' {
+				tmp[k] += 32
+			}
+		}
+		for j := 0; j < len(PreReleaseNames); j++ {
+			if PreReleaseNames[j] == Convert.B2S(tmp) {
+				v.PreRelease = j
+				break
+			} else if j == len(PreReleaseNames)-1 {
+				return nil, errors.New("faulty data")
+			}
+		}
+	case 5:
+		atoi, err := strconv.Atoi(Convert.B2S(tmp))
+		if err != nil {
+			return nil, err
+		}
+		v.PreReleaseCount = atoi
+	case 6:
+		v.BuildMetadata = Convert.B2S(tmp)
+	}
+
+	return &v, nil
+}
+func (v *Version) Cmp(nv *Version) int {
+	if v.Major != nv.Major {
+		if v.Major > nv.Major {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	if v.Minor != nv.Minor {
+		if v.Minor > nv.Minor {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	if v.Patch != nv.Patch {
+		if v.Patch > nv.Patch {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	if v.PreRelease != nv.PreRelease {
+		if v.PreRelease > nv.PreRelease {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	if v.PreReleaseCount != nv.PreReleaseCount {
+		if v.PreReleaseCount > nv.PreReleaseCount {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	return 0
+}
+
+func isNum(s uint8) bool {
+	if s >= 48 && s <= 57 {
+		return true
+	}
+	return false
+}

--- a/pkg/go-oneutils/Set/set.go
+++ b/pkg/go-oneutils/Set/set.go
@@ -1,0 +1,69 @@
+package Set
+
+import "sync"
+
+type Set map[string]struct{}
+
+func New() Set {
+	return make(map[string]struct{}, 64)
+}
+func (s Set) SAdd(strs ...string) {
+	for i := 0; i < len(strs); i++ {
+		s[strs[i]] = struct{}{}
+	}
+}
+func (s Set) SMembers() []string {
+	strs := make([]string, len(s))
+	strs = strs[:0]
+	for s2 := range s {
+		strs = append(strs, s2)
+	}
+	return strs
+}
+func (s Set) SIsMember(str string) bool {
+	_, err := s[str]
+	return err
+}
+func (s Set) SRem(str string) error {
+	_, err := s[str]
+	if err {
+
+	}
+	delete(s, str)
+	return nil
+}
+
+// SUnion 并集
+func (s Set) SUnion(sets ...Set) Set {
+	newset := AcquireSet()
+	for i := 0; i < len(sets); i++ {
+		for key, _ := range sets[i] {
+			newset.SAdd(key)
+		}
+	}
+	return newset
+}
+func (s Set) SCard() int {
+	return len(s)
+}
+
+func (s Set) Reset() {
+	for s2, _ := range s {
+		delete(s, s2)
+	}
+}
+
+var pool = sync.Pool{
+	New: func() any {
+		return Set{}
+	},
+}
+
+func AcquireSet() Set {
+	return pool.Get().(Set)
+}
+
+func ReleaseSet(s Set) {
+	s.Reset()
+	pool.Put(s)
+}

--- a/pkg/kpm/cli_client.go
+++ b/pkg/kpm/cli_client.go
@@ -1,0 +1,204 @@
+package kpm
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/ExecCmd"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/PathHandle"
+	"os"
+)
+
+type CliClient struct {
+	GitStore         *GlobalStore.FileStore
+	RegistryStore    *GlobalStore.FileStore
+	WorkDir          string
+	Root             string
+	RegistryAddr     string
+	RegistryAddrPath string
+	KclVmVersion     string
+	NestedMode       bool
+}
+
+func (c CliClient) Get(rb *RequireBase) error {
+	var store *GlobalStore.FileStore
+	if rb.Type == "git" {
+		store = c.GitStore
+	} else {
+		store = c.RegistryStore
+	}
+	exist, err := store.DirIsExist(rb.Name + "@" + string(rb.Version))
+	if err != nil {
+		return err
+	}
+
+	//找不到，开始查找元文件
+	metadata, err := LoadLocalMetadata(rb.Name, rb.Version, store)
+	if err != nil {
+		//找不到元文件,下载
+		err = c.PkgDownload(rb)
+		if err != nil {
+			return err
+		}
+		return err
+	}
+	if exist {
+		//找到包
+		println("found", rb.GetPkgString())
+		if rb.Integrity == "" {
+			rb.Integrity = metadata.Integrity
+		} else {
+			if rb.Integrity != metadata.Integrity {
+				e := errors.New("the package integrity check failed")
+
+				return e
+			}
+		}
+		return nil
+	}
+	println("not found pkg", rb.GetPkgString())
+	//找到元文件
+	if c.NestedMode {
+		err = c.Build(rb)
+	} else {
+		err = metadata.Build(store)
+	}
+
+	println("building pkg", rb.GetPkgString())
+	if err != nil {
+		return err
+	}
+	//下载成功则得到元数据，开始检查hash文件是否缺失
+
+	return nil
+}
+
+// PkgDownload 下载包
+func (c CliClient) PkgDownload(rb *RequireBase) error {
+	println("downloading pkg", rb.GetPkgString())
+	if rb.Type == "git" {
+		//git版本
+		err := PathHandle.RunInTempDir(func(tmppath string) error {
+			err := ExecCmd.Run(tmppath, "git", "clone", "--branch", string(rb.Version), "https://"+rb.Name)
+			if err != nil {
+				return err
+			}
+			t2 := tmppath + PathHandle.Separator + rb.GetShortName()
+			metadata, err := NewMetadata(rb.Name, t2, string(rb.Version), c.GitStore)
+			if err != nil {
+				return err
+			}
+			err = metadata.Save(c.GitStore)
+			if err != nil {
+				return err
+			}
+			if c.NestedMode {
+				err = c.Build(rb)
+			} else {
+				err = metadata.Build(c.GitStore)
+			}
+			if err != nil {
+				return err
+			}
+			rb.Integrity = metadata.Integrity
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		//仓库版本
+	}
+	return nil
+}
+
+func (c CliClient) LoadKpmFileStruct(rb *RequireBase) (*KpmFile, error) {
+	var store *GlobalStore.FileStore
+	if rb.Type == "git" {
+		store = kpmC.GitStore
+	} else {
+		store = kpmC.RegistryStore
+	}
+	path, err := store.GetDirPath(rb.Name + "@" + string(rb.Version))
+	if err != nil {
+		return nil, err
+	}
+	filebytes, err := os.ReadFile(path + PathHandle.Separator + "kpm.json")
+	if err != nil {
+		return nil, err
+	}
+	kf := KpmFile{}
+	err = json.Unmarshal(filebytes, &kf)
+	if err != nil {
+		return nil, err
+	}
+	return &kf, nil
+}
+
+func (c CliClient) LoadKpmFileStructInWorkdir() (*KpmFile, error) {
+	filebytes, err := os.ReadFile(c.WorkDir + PathHandle.Separator + "kpm.json")
+	if err != nil {
+		return nil, err
+	}
+	kf := KpmFile{}
+	err = json.Unmarshal(filebytes, &kf)
+	if err != nil {
+		return nil, err
+	}
+	return &kf, nil
+}
+
+func (c CliClient) SaveKpmFileInWorkdir(kf *KpmFile) error {
+	marshal, err := json.Marshal(&kf)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(c.WorkDir+PathHandle.Separator+"kpm.json", marshal, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c CliClient) Build(rb *RequireBase) error {
+	//先构建，再读文件，最后链接依赖
+	var store *GlobalStore.FileStore
+	if rb.Type == "git" {
+		store = kpmC.GitStore
+	} else {
+		store = kpmC.RegistryStore
+	}
+	md, err := LoadLocalMetadata(rb.Name, rb.Version, store)
+	if err != nil {
+		return err
+	}
+	err = store.BuildDir(md.Files, md.Name+"@"+string(md.Version))
+	if err != nil {
+		return err
+	}
+	fileStruct, err := c.LoadKpmFileStruct(rb)
+	if err != nil {
+		if err == os.ErrNotExist {
+			return nil
+		}
+		return err
+	}
+	//_ = fileStruct
+	for s, base := range fileStruct.Direct {
+		var rbstore *GlobalStore.FileStore
+		if rb.Type == "git" {
+			rbstore = kpmC.GitStore
+		} else {
+			rbstore = kpmC.RegistryStore
+		}
+		path, err := store.GetDirPath(rb.Name)
+		if err != nil {
+			return err
+		}
+		err = rbstore.Link(base.Name+"@"+string(base.Version), path+"@"+string(rb.Version)+PathHandle.Separator+"external"+PathHandle.Separator+s)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/kpm/cli_test.go
+++ b/pkg/kpm/cli_test.go
@@ -1,0 +1,58 @@
+package kpm
+
+import (
+	"testing"
+)
+
+func TestInit(t *testing.T) {
+
+	// kpm init test_example
+	err := CLI([]string{"kpm", "init", "test_example"}...)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+}
+func TestAdd(t *testing.T) {
+	// kpm add -git github.com/orangebees/konfig@v0.0.1
+	err := CLI([]string{"kpm", "add", "-git", "github.com/orangebees/konfig@v0.0.1"}...)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+}
+func TestDel(t *testing.T) {
+	// kpm del konfig
+	err := CLI([]string{"kpm", "del", "konfig"}...)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+}
+func TestAddLatest(t *testing.T) {
+	// kpm add -git github.com/orangebees/konfig@v0.0.1
+	err := CLI([]string{"kpm", "add", "-git", "github.com/orangebees/konfig"}...)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+}
+func TestDownload(t *testing.T) {
+
+	// kpm download
+	err := CLI([]string{"kpm", "download"}...)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+}
+
+func TestStore(t *testing.T) {
+	// kpm store add -git github.com/orangebees/konfig@v0.0.1
+	err := CLI([]string{"kpm", "store", "add", "-git", "github.com/orangebees/konfig@v0.0.1"}...)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+
+}

--- a/pkg/kpm/cmd_add.go
+++ b/pkg/kpm/cmd_add.go
@@ -1,0 +1,159 @@
+package kpm
+
+import (
+	"errors"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/PathHandle"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Semver"
+	"github.com/urfave/cli/v2"
+	"os"
+)
+
+func NewAddCmd() *cli.Command {
+	return &cli.Command{
+		Hidden: false,
+		Name:   "add",
+		Usage:  "add dependencies pkg",
+		Flags: []cli.Flag{&cli.BoolFlag{
+			Name:  "git",
+			Usage: "add git pkg",
+		},
+		//&cli.StringFlag{
+		//	Name:  "",
+		//	Usage: "",
+		//},
+		},
+		Action: func(c *cli.Context) error {
+			if c.NArg() == 0 {
+				cli.ShowAppHelpAndExit(c, 0)
+			}
+			println("add...")
+			kf, err := kpmC.LoadKpmFileStructInWorkdir()
+			if err != nil {
+				return err
+			}
+			ps := c.Args().Slice()[c.Args().Len()-1]
+			var rbstore *GlobalStore.FileStore
+			if c.Bool("git") {
+				ps = "git:" + ps
+				rbstore = kpmC.GitStore
+			} else {
+				ps = "registry:" + ps
+				rbstore = kpmC.RegistryStore
+			}
+
+			pkgStruct, err := GetRequirePkgStruct(ps)
+			if err != nil {
+				return err
+			}
+			rb := RequireBase{
+				RequirePkgStruct: *pkgStruct,
+			}
+			err = kpmC.Get(&rb)
+			if err != nil {
+				return err
+			}
+			if kf.Direct == nil {
+				kf.Direct = make(DirectRequire, 16)
+			}
+			if kf.Indirect == nil {
+				kf.Indirect = make(IndirectRequire, 16)
+			}
+			shortname := rb.GetShortName()
+			_, ok := kf.Direct[shortname]
+			if ok {
+				e := errors.New("this package already exists")
+				return e
+			}
+			kf.Direct[shortname] = rb
+			dkf, err := kpmC.LoadKpmFileStruct(&rb)
+			if err == nil {
+				//找到文件
+				kfv, err := Semver.NewFromString(kf.KclvmMinVersion)
+				if err != nil {
+					return err
+				}
+				dkfv, err := Semver.NewFromString(dkf.KclvmMinVersion)
+				if err != nil {
+					return err
+				}
+				if kfv.Cmp(dkfv) == -1 {
+					e := errors.New("the KclvmMinVersion of the added dependency " + shortname + " is greater than the KclvmMinVersion of the workspace")
+
+					return e
+				}
+				for k, v := range dkf.Indirect {
+					kf.Indirect[k] = v
+					//
+					dpkgStruct, err := GetRequirePkgStruct(ps)
+					if err != nil {
+						return err
+					}
+					drb := RequireBase{
+						RequirePkgStruct: *dpkgStruct,
+					}
+					err = kpmC.Get(&drb)
+					if err != nil {
+						return err
+					}
+					if !kpmC.NestedMode {
+						//平铺模式
+						var tmpstore *GlobalStore.FileStore
+						if drb.Type == "git" {
+							tmpstore = kpmC.GitStore
+						} else {
+							tmpstore = kpmC.RegistryStore
+						}
+						tmptargetPath := kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + PathHandle.URLToLocalDirPath(drb.Name) + "@" + string(drb.Version)
+						_ = os.Remove(tmptargetPath)
+						err = tmpstore.Link(drb.Name+"@"+string(drb.Version), tmptargetPath)
+						if err != nil {
+							return err
+						}
+					}
+				}
+				for _, v := range dkf.Direct {
+					kf.Indirect[v.GetPkgString()] = v.Integrity
+					err = kpmC.Get(&v)
+					if err != nil {
+						return err
+					}
+					if !kpmC.NestedMode {
+						//平铺模式
+						var tmpstore *GlobalStore.FileStore
+						if v.Type == "git" {
+							tmpstore = kpmC.GitStore
+						} else {
+							tmpstore = kpmC.RegistryStore
+						}
+						tmptargetPath := kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + PathHandle.URLToLocalDirPath(v.Name) + "@" + string(v.Version)
+						_ = os.Remove(tmptargetPath)
+						err = tmpstore.Link(v.Name+"@"+string(v.Version), tmptargetPath)
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
+			var targetPath string
+			if kpmC.NestedMode {
+				targetPath = kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + shortname
+			} else {
+				//待开发
+				targetPath = kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + PathHandle.URLToLocalDirPath(rb.Name) + "@" + string(rb.Version)
+			}
+			_ = os.Remove(targetPath)
+			err = rbstore.Link(rb.Name+"@"+string(rb.Version), targetPath)
+			if err != nil {
+				return err
+			}
+			println("add", shortname, "success")
+			//保存
+			err = kpmC.SaveKpmFileInWorkdir(kf)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/kpm/cmd_del.go
+++ b/pkg/kpm/cmd_del.go
@@ -1,0 +1,54 @@
+package kpm
+
+import (
+	"errors"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/PathHandle"
+	"github.com/urfave/cli/v2"
+	"io/fs"
+	"os"
+)
+
+func NewDelCmd() *cli.Command {
+	return &cli.Command{
+		Hidden: false,
+		Name:   "del",
+		Usage:  "del  dependencies pkg",
+		Action: func(c *cli.Context) error {
+			if c.NArg() == 0 {
+				cli.ShowAppHelpAndExit(c, 0)
+			}
+			println("del...")
+			kf, err := kpmC.LoadKpmFileStructInWorkdir()
+			if err != nil {
+				return err
+			}
+			shortname := c.Args().Slice()[c.Args().Len()-1]
+
+			rb, ok := kf.Direct[shortname]
+			if !ok {
+				e := errors.New("this package does not exists")
+				return e
+			}
+			delete(kf.Direct, shortname)
+			var targetPath string
+			if kpmC.NestedMode {
+				targetPath = kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + shortname
+			} else {
+				//待开发
+				targetPath = kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + PathHandle.URLToLocalDirPath(rb.Name) + "@" + string(rb.Version)
+			}
+			err = os.Remove(targetPath)
+			if err != nil {
+				if !(errors.Is(err, os.ErrNotExist) || errors.Is(err, &fs.PathError{Op: "remove", Path: targetPath})) {
+					return err
+				}
+			}
+			println("delete", shortname, "success")
+			err = kpmC.SaveKpmFileInWorkdir(kf)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/kpm/cmd_download.go
+++ b/pkg/kpm/cmd_download.go
@@ -1,0 +1,99 @@
+package kpm
+
+import (
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/PathHandle"
+	"github.com/urfave/cli/v2"
+	"os"
+)
+
+func NewDownloadCmd() *cli.Command {
+	return &cli.Command{
+		Hidden: false,
+		Name:   "download",
+		Usage:  "download dependencies pkg to local cache and link to workspace",
+		Action: func(c *cli.Context) error {
+			if c.NArg() != 0 {
+				cli.ShowAppHelpAndExit(c, 0)
+			}
+			println("download...")
+			kf, err := kpmC.LoadKpmFileStructInWorkdir()
+			if err != nil {
+				return err
+			}
+			globalWriterFlag := false
+			for ps, integrity := range kf.Indirect {
+				pkgStruct, err := GetRequirePkgStruct(ps)
+				if err != nil {
+					return err
+				}
+				rb := RequireBase{
+					RequirePkgStruct: *pkgStruct,
+					Integrity:        integrity,
+				}
+				writerFlag := rb.Integrity == ""
+				err = kpmC.Get(&rb)
+				if err != nil {
+
+					return err
+				}
+				if !kpmC.NestedMode {
+					//平铺模式
+					var tmpstore *GlobalStore.FileStore
+					if rb.Type == "git" {
+						tmpstore = kpmC.GitStore
+					} else {
+						tmpstore = kpmC.RegistryStore
+					}
+					tmptargetPath := kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + PathHandle.URLToLocalDirPath(rb.Name) + "@" + string(rb.Version)
+					_ = os.Remove(tmptargetPath)
+					err = tmpstore.Link(rb.Name+"@"+string(rb.Version), tmptargetPath)
+					if err != nil {
+						return err
+					}
+				}
+				if writerFlag {
+					globalWriterFlag = true
+					kf.Indirect[ps] = rb.Integrity
+				}
+			}
+			for rbn, rb := range kf.Direct {
+				writerFlag := rb.Integrity == ""
+				err = kpmC.Get(&rb)
+				if err != nil {
+					return err
+				}
+				var rbstore *GlobalStore.FileStore
+				if rb.Type == "git" {
+					rbstore = kpmC.GitStore
+				} else {
+					rbstore = kpmC.RegistryStore
+				}
+				var targetPath string
+				if kpmC.NestedMode {
+					targetPath = kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + rbn
+				} else {
+					//待开发
+					targetPath = kpmC.WorkDir + PathHandle.Separator + "external" + PathHandle.Separator + PathHandle.URLToLocalDirPath(rb.Name) + "@" + string(rb.Version)
+				}
+				_ = os.Remove(targetPath)
+				err = rbstore.Link(rb.Name+"@"+string(rb.Version), targetPath)
+				if err != nil {
+					return err
+				}
+				if writerFlag {
+					globalWriterFlag = true
+					kf.Direct[rbn] = rb
+				}
+			}
+
+			if globalWriterFlag {
+				err = kpmC.SaveKpmFileInWorkdir(kf)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/kpm/cmd_init.go
+++ b/pkg/kpm/cmd_init.go
@@ -1,0 +1,61 @@
+package kpm
+
+import (
+	"encoding/json"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Convert"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/PathHandle"
+	"github.com/urfave/cli/v2"
+	"os"
+)
+
+func NewInitCmd() *cli.Command {
+	return &cli.Command{
+		Hidden: false,
+		Name:   "init",
+		Usage:  "initialize new module in current directory",
+		Action: func(c *cli.Context) error {
+			if c.NArg() == 0 {
+				println("not args...")
+				cli.ShowAppHelpAndExit(c, 0)
+			}
+			println("init...")
+			_, err := os.Stat(kpmC.WorkDir + PathHandle.Separator + "kpm.json")
+			if err == nil {
+				println("kpm.json is exist")
+				return nil
+			}
+
+			marshal, err := json.Marshal(KpmFile{
+				PackageName:     c.Args().First(),
+				KclvmMinVersion: kpmC.KclVmVersion,
+				Direct:          nil,
+				Indirect:        nil,
+			})
+			if err != nil {
+				return err
+			}
+			err = os.WriteFile(kpmC.WorkDir+PathHandle.Separator+"kpm.json", marshal, 0777)
+			if err != nil {
+				return err
+			}
+			println("Create kpm.json success!")
+			err = os.WriteFile(kpmC.WorkDir+PathHandle.Separator+".gitignore", Convert.S2B(DefaultGitignore), 0777)
+			if err != nil {
+				return err
+			}
+			println("Create .gitignore success!")
+			_, err = os.Stat(kpmC.WorkDir + PathHandle.Separator + "kcl.mod")
+			if err == nil {
+				return nil
+			}
+			//The file does not exist, so this file is created
+			err = os.WriteFile(kpmC.WorkDir+PathHandle.Separator+"kcl.mod", Convert.S2B(DefaultKclModContent), 0777)
+			if err != nil {
+				return err
+			}
+			println("Create kcl.mod success!")
+
+			return nil
+		},
+	}
+}

--- a/pkg/kpm/cmd_main.go
+++ b/pkg/kpm/cmd_main.go
@@ -1,0 +1,29 @@
+package kpm
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+func CLI(args ...string) error {
+	app := cli.NewApp()
+	app.Name = "kpm"
+	app.Usage = "kpm is a kcl package manager"
+	app.Version = "v0.0.1-alpha.1"
+	app.UsageText = CliHelp
+	app.Commands = []*cli.Command{
+		NewInitCmd(),
+		NewAddCmd(),
+		NewDelCmd(),
+		NewDownloadCmd(),
+		NewStoreCmd(),
+	}
+	err := Setup()
+	if err != nil {
+		return err
+	}
+	err = app.Run(args)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kpm/cmd_setup.go
+++ b/pkg/kpm/cmd_setup.go
@@ -41,8 +41,9 @@ func Setup() error {
 		return err
 	}
 	kpmC.RegistryAddrPath = parse.Host
-	if tmp := os.Getenv("KPM_NESTEDMODE "); tmp == "true" {
+	if tmp := os.Getenv("KPM_NESTEDMODE"); tmp == "true" {
 		kpmC.NestedMode = true
+		println("NestedMode is true!")
 	}
 	kpmC.GitStore, err = GlobalStore.NewFileStore(GlobalStore.FileStoreConfig{
 		Root:                   kpmC.Root,

--- a/pkg/kpm/cmd_setup.go
+++ b/pkg/kpm/cmd_setup.go
@@ -1,0 +1,71 @@
+package kpm
+
+import (
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/PathHandle"
+	"net/url"
+	"os"
+	"os/user"
+)
+
+var kpmC CliClient
+var systemPkg = []string{"base64", "crypto", "json", "math", "net", "regex", "time", "units", "yaml"}
+
+func Setup() error {
+	var err error
+	kpmC.WorkDir, err = os.Getwd()
+	if err != nil {
+		return nil
+	}
+	//Load environment variables
+	if tmp := os.Getenv("KPM_ROOT"); tmp == "" {
+		home := ""
+		u, err := user.Current()
+		if err != nil {
+			if tmphome := os.Getenv("HOME"); tmphome != "" {
+				home = tmphome
+			} else {
+				return nil
+			}
+		}
+		home = u.HomeDir
+		kpmC.Root = home + PathHandle.Separator + "kpm"
+	}
+	if tmp := os.Getenv("KPM_SERVER_ADDR"); tmp != "" {
+		kpmC.RegistryAddr = tmp
+	} else {
+		kpmC.RegistryAddr = DefaultRegistryAddr
+	}
+	parse, err := url.Parse(kpmC.RegistryAddr)
+	if err != nil {
+		return err
+	}
+	kpmC.RegistryAddrPath = parse.Host
+	if tmp := os.Getenv("KPM_NESTEDMODE "); tmp == "true" {
+		kpmC.NestedMode = true
+	}
+	kpmC.GitStore, err = GlobalStore.NewFileStore(GlobalStore.FileStoreConfig{
+		Root:                   kpmC.Root,
+		Metadata:               "git" + PathHandle.Separator + "metadata",
+		Build:                  "git" + PathHandle.Separator + "kcl_modules",
+		Store:                  "store" + PathHandle.Separator + "v1" + PathHandle.Separator + "files",
+		BucketCountIndexNumber: 2,
+		BucketAllocationMethod: "hashStrPrefix",
+		BucketHashType:         "sha512",
+	}, GlobalStore.IgnoreDotGitPath, GlobalStore.IgnoreDotExternalPath)
+	kpmC.RegistryStore, err = GlobalStore.NewFileStore(GlobalStore.FileStoreConfig{
+		Root:                   kpmC.Root,
+		Metadata:               "registry" + PathHandle.Separator + kpmC.RegistryAddrPath + PathHandle.Separator + "metadata",
+		Build:                  "registry" + PathHandle.Separator + kpmC.RegistryAddrPath + PathHandle.Separator + "kcl_modules",
+		Store:                  "store" + PathHandle.Separator + "v1" + PathHandle.Separator + "files",
+		BucketCountIndexNumber: 2,
+		BucketAllocationMethod: "hashStrPrefix",
+		BucketHashType:         "sha512",
+	}, GlobalStore.IgnoreDotGitPath, GlobalStore.IgnoreDotExternalPath)
+
+	if err != nil {
+		return err
+	}
+	kpmC.KclVmVersion = KclvmAbiVersion
+	return nil
+}

--- a/pkg/kpm/cmd_store.go
+++ b/pkg/kpm/cmd_store.go
@@ -1,0 +1,36 @@
+package kpm
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+func NewStoreCmd() *cli.Command {
+	return &cli.Command{
+		Hidden: false,
+		Name:   "store",
+		Usage:  "Reads and performs actions on kpm store that is on the current filesystem",
+		Action: func(c *cli.Context) error {
+			if c.NArg() == 0 {
+				cli.ShowAppHelpAndExit(c, 0)
+			}
+			app := cli.NewApp()
+			app.Name = "store"
+			app.Usage = "Reads and performs actions on kpm store that is on the current filesystem"
+			app.Version = "v0.0.1-alpha.2"
+			app.UsageText = CliHelp
+			app.Commands = []*cli.Command{
+				NewStoreAddCmd(),
+				NewStoreAddFileCmd(),
+			}
+			//Add a parameter that ensures that the parameter is associated with "os. Args" are consistent in number。
+			nargs := make([]string, c.NArg())
+			nargs = nargs[:1]
+			nargs = append(nargs, c.Args().Slice()...)
+			err := app.Run(nargs)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/kpm/cmd_store_add.go
+++ b/pkg/kpm/cmd_store_add.go
@@ -1,0 +1,42 @@
+package kpm
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+func NewStoreAddCmd() *cli.Command {
+	return &cli.Command{
+		Hidden: false,
+		Name:   "add",
+		Usage:  "Add packages to the global store",
+		Flags: []cli.Flag{&cli.BoolFlag{
+			Name:  "git",
+			Usage: "add git pkg",
+		}},
+		Action: func(c *cli.Context) error {
+			if c.NArg() == 0 {
+				cli.ShowAppHelpAndExit(c, 0)
+			}
+			//Add packages to the global store
+			ps := c.Args().Slice()[c.Args().Len()-1]
+			if c.Bool("git") {
+				ps = "git:" + ps
+			} else {
+				ps = "registry:" + ps
+			}
+			pkgStruct, err := GetRequirePkgStruct(ps)
+			if err != nil {
+				return err
+			}
+			rb := RequireBase{
+				RequirePkgStruct: *pkgStruct,
+			}
+			err = kpmC.Get(&rb)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}

--- a/pkg/kpm/cmd_store_addfile.go
+++ b/pkg/kpm/cmd_store_addfile.go
@@ -1,0 +1,26 @@
+package kpm
+
+import (
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+	"github.com/urfave/cli/v2"
+)
+
+func NewStoreAddFileCmd() *cli.Command {
+	return &cli.Command{
+		Hidden: false,
+		Name:   "addfile",
+		Usage:  "Add the current working directory to the global store",
+		Action: func(c *cli.Context) error {
+			if c.NArg() == 0 {
+				cli.ShowAppHelpAndExit(c, 0)
+			}
+			//Add the current working directory to the global store
+			fim, err := kpmC.GitStore.AddDir(kpmC.WorkDir)
+			if err != nil {
+				return err
+			}
+			GlobalStore.ReleaseFileInfoMap(fim)
+			return nil
+		},
+	}
+}

--- a/pkg/kpm/help.go
+++ b/pkg/kpm/help.go
@@ -1,0 +1,11 @@
+package kpm
+
+const (
+	CliHelp         = `kpm  <command> [arguments]...`
+	KclvmAbiVersion = "v0.4.3"
+)
+const DefaultKclModContent = string(`[expected]
+kclvm_version="` + KclvmAbiVersion + `"`)
+
+const DefaultRegistryAddr = "https://kpm.kusionstack.io"
+const DefaultGitignore = "/external/\n"

--- a/pkg/kpm/kclfile.go
+++ b/pkg/kpm/kclfile.go
@@ -1,0 +1,164 @@
+package kpm
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Convert"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Set"
+	"github.com/valyala/bytebufferpool"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type KCLFile struct {
+	//文件路径
+	Path string
+	//文件内容
+	Body []byte
+	//导入集合
+	Imports Set.Set
+	//写入标志
+	WriterFlag bool
+}
+
+func NewKCLFileFromFile(path string) (*KCLFile, error) {
+	kclF := &KCLFile{
+		Path:       path,
+		Body:       nil,
+		Imports:    Set.New(),
+		WriterFlag: false,
+	}
+	//读取每一行
+	rawbody, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	//rawbody := Convert.S2B(Def)
+	r := bufio.NewReader(bytes.NewReader(rawbody))
+	linecount := 0
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil && err != io.EOF {
+			//遇到未知错误
+			panic(err)
+		}
+		if err == io.EOF {
+			break
+		}
+		linecount++
+		line = strings.TrimSpace(line)
+		linelen := len(line)
+
+		if linelen <= 6 {
+			//跳过无效短行
+			continue
+		}
+		if line[0:1] == "#" {
+			//跳过注释
+			continue
+		}
+		if line[0:6] != "import" {
+			//遇到非import直接退出
+			break
+		}
+		lastbyte := ' '
+		var modname []byte
+		loadmodname := false
+		for i := 6; i < linelen; i++ {
+			//当上一个元素是空格，这个元素不是空格的时候跳入
+
+			if !loadmodname {
+				if lastbyte == ' ' && line[i] != ' ' {
+					loadmodname = true
+					lastbyte = int32(line[i])
+					modname = append(modname, line[i])
+					continue
+				}
+			}
+			//当上一个元素不是空格，这个元素是空格的时候跳出
+			if lastbyte != ' ' && line[i] == ' ' {
+				break
+			}
+			modname = append(modname, line[i])
+			lastbyte = int32(line[i])
+		}
+		//检查是否是系统模块
+		issysmod := false
+		modnamestr := string(modname[1:])
+		for i := 0; i < len(systemPkg); i++ {
+			if systemPkg[i] == modnamestr {
+				issysmod = true
+				break
+
+			}
+		}
+		if issysmod {
+			kclF.Imports.SAdd(modnamestr)
+		}
+
+	}
+	for i := 0; i >= len(rawbody) || linecount > 0; i++ {
+		if linecount == 1 {
+			kclF.Body = rawbody[i:]
+			break
+		}
+		if rawbody[i] == '\n' {
+			linecount--
+		}
+
+	}
+	return kclF, nil
+}
+func (f *KCLFile) Save() error {
+	if f.WriterFlag {
+		ipt := f.Imports.SMembers()
+		b := bytebufferpool.Get()
+		defer bytebufferpool.Put(b)
+		for i := 0; i < len(ipt); i++ {
+			b.WriteString("import ")
+			b.WriteString(ipt[i])
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+		b.Write(f.Body)
+		err := os.WriteFile(f.Path, b.Bytes(), 0777)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (f *KCLFile) AddPkgPrefix(str string) {
+	ipt := f.Imports.SMembers()
+	for i := 0; i < len(ipt); i++ {
+		f.WriterFlag = true
+		ipt[i] = str + "." + ipt[i]
+	}
+	if f.WriterFlag {
+		f.Imports.Reset()
+		f.Imports.SAdd(ipt...)
+	}
+}
+func (f *KCLFile) AddPkgPrefixFromPath(str string) {
+	var newPrefix []byte
+	for i := 0; i < len(str); i++ {
+		tmp := str[i]
+		if tmp != filepath.Separator {
+			newPrefix = append(newPrefix, tmp)
+		} else {
+			newPrefix = append(newPrefix, '.')
+		}
+
+	}
+	ipt := f.Imports.SMembers()
+	for i := 0; i < len(ipt); i++ {
+		f.WriterFlag = true
+		ipt[i] = Convert.B2S(newPrefix) + "." + ipt[i]
+	}
+	if f.WriterFlag {
+		f.Imports.Reset()
+		f.Imports.SAdd(ipt...)
+	}
+}

--- a/pkg/kpm/kpmfile.go
+++ b/pkg/kpm/kpmfile.go
@@ -1,0 +1,18 @@
+package kpm
+
+import (
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+)
+
+type KpmFile struct {
+	//PackageName,this is usually the code source repository address
+	PackageName string `json:"package_name"`
+	//KclvmMinVersion,used to identify version conflict states
+	KclvmMinVersion string `json:"kclvm_min_version"`
+	//Dependencies that are directly needed, aliases are not duplicated
+	Direct DirectRequire `json:"direct,omitempty"`
+	//Indirect dependencies, do not look at the alias, the package name and version are unique
+	Indirect IndirectRequire `json:"indirect,omitempty"`
+}
+type DirectRequire map[string]RequireBase
+type IndirectRequire map[PkgString]GlobalStore.Integrity

--- a/pkg/kpm/metadata.go
+++ b/pkg/kpm/metadata.go
@@ -1,0 +1,103 @@
+package kpm
+
+import (
+	"encoding/json"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Convert"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Semver"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Set"
+	"os"
+	"sort"
+	"strings"
+)
+
+type Metadata struct {
+	Name        string                  `json:"name"`
+	Version     Semver.VersionString    `json:"version"`
+	Integrity   GlobalStore.Integrity   `json:"integrity"`
+	PackageSize int64                   `json:"package_size"`
+	SubPkgName  []string                `json:"sub_pkg_name,omitempty"`
+	Files       GlobalStore.FileInfoMap `json:"files,omitempty"`
+}
+
+func NewMetadata(pkgName, pkgPath string, pkgVersion string, gs *GlobalStore.FileStore) (*Metadata, error) {
+	fim, err := gs.AddDir(pkgPath)
+	if err != nil {
+		return nil, err
+	}
+	ver, err := Semver.NewFromString(pkgVersion)
+	if err != nil {
+		return nil, err
+	}
+	m := Metadata{
+		Name:       pkgName,
+		Version:    Semver.VersionString(ver.TagString()),
+		Integrity:  fim.GetIntegrity(),
+		SubPkgName: nil,
+		Files:      fim,
+	}
+	set := Set.AcquireSet()
+	defer Set.ReleaseSet(set)
+	for k, info := range fim {
+		//计算包大小
+		m.PackageSize += info.Size
+		//添加子包名字
+		if strings.HasSuffix(k, ".k") {
+			tmp := make([]byte, len(k))
+			tmp = tmp[:0]
+			index := 0
+			for i := 0; i < len(k); i++ {
+				if k[i] == '/' {
+					index = i
+					tmp = append(tmp, '.')
+				} else {
+					tmp = append(tmp, k[i])
+				}
+			}
+			set.SAdd(Convert.B2S(tmp[:index]))
+		}
+		m.SubPkgName = set.SMembers()
+		sort.Strings(m.SubPkgName)
+	}
+	return &m, nil
+}
+func LoadLocalMetadata(pkgName string, pkgVersion Semver.VersionString, gs *GlobalStore.FileStore) (*Metadata, error) {
+	path, err := gs.GetMetadataPath(pkgName + "@" + string(pkgVersion))
+	if err != nil {
+		return nil, err
+	}
+	path += ".json"
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	md := Metadata{}
+	err = json.Unmarshal(file, &md)
+	if err != nil {
+		return nil, err
+	}
+	return &md, nil
+}
+func (md *Metadata) Build(gs *GlobalStore.FileStore) error {
+	err := gs.BuildDir(md.Files, md.Name+"@"+string(md.Version))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (md *Metadata) Save(gs *GlobalStore.FileStore) error {
+	path, err := gs.GetMetadataPath(md.Name + "@" + string(md.Version))
+	if err != nil {
+		return err
+	}
+	path = path + ".json"
+	marshal, err := json.Marshal(md)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(path, marshal, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kpm/pkg_str.go
+++ b/pkg/kpm/pkg_str.go
@@ -1,0 +1,169 @@
+package kpm
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Semver"
+	"github.com/valyala/fasthttp"
+	"strings"
+	"time"
+)
+
+type PkgString = string
+
+func GetRequirePkgStruct(ps PkgString) (*RequirePkgStruct, error) {
+	b := ps
+	index1, index2 := 0, 0
+	index3, indexlast := 0, 0
+	var ver string
+	for i := 0; i < len(b); i++ {
+		switch b[i] {
+		case ':':
+			index1 = i
+		case '/':
+			indexlast = index3
+			index3 = i
+
+		case '@':
+			index2 = i
+			break
+		}
+	}
+	if index1 == 0 {
+		return nil, errors.New("parsing failed")
+	}
+
+	if !(b[:index1] == "git" || b[:index1] == "registry") {
+		return nil, errors.New("parsing failed")
+	}
+	if index2 == 0 || strings.HasSuffix(b, "@latest") {
+		index2 = len(ps)
+		//获取最新版本
+		//println(b[indexlast:index2], "555")
+		//"https://gitee.com/api/v5/repos"
+		var u string
+		if strings.HasPrefix(b, "git:github.com") {
+			u = "https://api.github.com/repos" + b[indexlast:index2] + "/releases/latest"
+		} else if strings.HasPrefix(b, "git:gitee.com") {
+			u = "https://gitee.com/api/v5/repos" + b[indexlast:index2] + "/releases/latest"
+		} else {
+			return nil, errors.New("unsupported repository type, failed to get latest version")
+		}
+
+		req := fasthttp.AcquireRequest()
+		defer fasthttp.ReleaseRequest(req)
+		req.Header.SetMethod("GET")
+		req.SetRequestURI(u)
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseResponse(resp)
+		if err := fasthttp.Do(req, resp); err != nil {
+			return nil, err
+		}
+		if strings.HasPrefix(b, "git:github.com") {
+			ginfo := GithubInfo{}
+			err := json.Unmarshal(resp.Body(), &ginfo)
+			if err != nil {
+				return nil, err
+			}
+			ver = ginfo.TagName
+		} else {
+			ginfo := GiteeInfo{}
+			err := json.Unmarshal(resp.Body(), &ginfo)
+			if err != nil {
+				return nil, err
+			}
+			ver = ginfo.TagName
+		}
+
+	} else {
+		ver = b[index2+1:]
+	}
+
+	//if pkgStruct.Version == "" {
+	//	//https://api.github.com/repos/orangebees/go-oneutils/releases/latest
+	//}
+	//if index1 == 0 || index2 == 0 || index1 >= index2 {
+	//	return nil, errors.New("parsing failed")
+	//}
+
+	return &RequirePkgStruct{
+		Type:    b[:index1],
+		Name:    b[index1+1 : index2],
+		Version: Semver.VersionString(ver),
+	}, nil
+
+}
+
+type GithubInfo struct {
+	Url       string `json:"url"`
+	AssetsUrl string `json:"assets_url"`
+	UploadUrl string `json:"upload_url"`
+	HtmlUrl   string `json:"html_url"`
+	Id        int    `json:"id"`
+	Author    struct {
+		Login             string `json:"login"`
+		Id                int    `json:"id"`
+		NodeId            string `json:"node_id"`
+		AvatarUrl         string `json:"avatar_url"`
+		GravatarId        string `json:"gravatar_id"`
+		Url               string `json:"url"`
+		HtmlUrl           string `json:"html_url"`
+		FollowersUrl      string `json:"followers_url"`
+		FollowingUrl      string `json:"following_url"`
+		GistsUrl          string `json:"gists_url"`
+		StarredUrl        string `json:"starred_url"`
+		SubscriptionsUrl  string `json:"subscriptions_url"`
+		OrganizationsUrl  string `json:"organizations_url"`
+		ReposUrl          string `json:"repos_url"`
+		EventsUrl         string `json:"events_url"`
+		ReceivedEventsUrl string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"author"`
+	NodeId          string        `json:"node_id"`
+	TagName         string        `json:"tag_name"`
+	TargetCommitish string        `json:"target_commitish"`
+	Name            string        `json:"name"`
+	Draft           bool          `json:"draft"`
+	Prerelease      bool          `json:"prerelease"`
+	CreatedAt       time.Time     `json:"created_at"`
+	PublishedAt     time.Time     `json:"published_at"`
+	Assets          []interface{} `json:"assets"`
+	TarballUrl      string        `json:"tarball_url"`
+	ZipballUrl      string        `json:"zipball_url"`
+	Body            string        `json:"body"`
+}
+
+// GiteeInfo https://gitee.com/api/v5/repos/dotnetchina/SmartSQL/releases/latest
+type GiteeInfo struct {
+	Id              int    `json:"id"`
+	TagName         string `json:"tag_name"`
+	TargetCommitish string `json:"target_commitish"`
+	Prerelease      bool   `json:"prerelease"`
+	Name            string `json:"name"`
+	Body            string `json:"body"`
+	Author          struct {
+		Id                int    `json:"id"`
+		Login             string `json:"login"`
+		Name              string `json:"name"`
+		AvatarUrl         string `json:"avatar_url"`
+		Url               string `json:"url"`
+		HtmlUrl           string `json:"html_url"`
+		Remark            string `json:"remark"`
+		FollowersUrl      string `json:"followers_url"`
+		FollowingUrl      string `json:"following_url"`
+		GistsUrl          string `json:"gists_url"`
+		StarredUrl        string `json:"starred_url"`
+		SubscriptionsUrl  string `json:"subscriptions_url"`
+		OrganizationsUrl  string `json:"organizations_url"`
+		ReposUrl          string `json:"repos_url"`
+		EventsUrl         string `json:"events_url"`
+		ReceivedEventsUrl string `json:"received_events_url"`
+		Type              string `json:"type"`
+	} `json:"author"`
+	CreatedAt time.Time `json:"created_at"`
+	Assets    []struct {
+		BrowserDownloadUrl string `json:"browser_download_url"`
+		Name               string `json:"name,omitempty"`
+	} `json:"assets"`
+}

--- a/pkg/kpm/require.go
+++ b/pkg/kpm/require.go
@@ -1,0 +1,34 @@
+package kpm
+
+import (
+	"github.com/KusionStack/kpm/pkg/go-oneutils/GlobalStore"
+	"github.com/KusionStack/kpm/pkg/go-oneutils/Semver"
+)
+
+type Require struct {
+	RequireBase
+	Alias string `json:"alias,omitempty"`
+}
+
+type RequireBase struct {
+	RequirePkgStruct
+	Integrity GlobalStore.Integrity `json:"integrity"`
+}
+
+type RequirePkgStruct struct {
+	Type    string               `json:"type"`
+	Name    string               `json:"name"`
+	Version Semver.VersionString `json:"version"`
+}
+
+func (rps *RequirePkgStruct) GetPkgString() PkgString {
+	return rps.Type + ":" + rps.Name + "@" + string(rps.Version)
+}
+func (rps *RequirePkgStruct) GetShortName() string {
+	for i := len(rps.Name) - 1; i >= 0; i-- {
+		if rps.Name[i] == '/' {
+			return rps.Name[i+1:]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION

Add Package Manager Basic Support.Initial commands support for init, add,download, and del. You can add packages from GitHub


Example：
```bash
/app # kpm init test_project
init...
Create kpm.json success!
Create .gitignore success!
Create kcl.mod success!
/app # kpm add -git github.com/orangebees/konfig
add...
downloading pkg git:github.com/orangebees/konfig@v0.0.1
add konfig success
/app # ls
external  kcl.mod   kpm.json
/app # rm -rf external
/app # kpm download 
download...
found git:github.com/orangebees/konfig@v0.0.1
/app # kpm del konfig
del...
delete konfig success
