### PR TITLE
fix: fix the localpath when 'kpm add' from oci registry without tag.

### DIFF
--- a/pkg/mod/modfile_test.go
+++ b/pkg/mod/modfile_test.go
@@ -174,6 +174,7 @@ func TestGetFilePath(t *testing.T) {
 	assert.Equal(t, mfile.GetModLockFilePath(), filepath.Join(testPath, MOD_LOCK_FILE))
 }
 
+// TestDownloadGit test download from oci registry.
 func TestDownloadOci(t *testing.T) {
 	testPath := filepath.Join(getTestDir("download"), "k8s_1.27.2")
 	err := os.MkdirAll(testPath, 0755)
@@ -193,7 +194,7 @@ func TestDownloadOci(t *testing.T) {
 
 	dep, err := depFromOci.Download(testPath)
 	assert.Equal(t, dep.Name, "k8s")
-	assert.Equal(t, dep.FullName, "")
+	assert.Equal(t, dep.FullName, "k8s_1.27.2")
 	assert.Equal(t, dep.Version, "1.27.2")
 	assert.Equal(t, dep.Sum, "ZI7L/uz53aDOIgVgxBbEPG7wGCWR+Gd3hhgYYRLoIY4=")
 	assert.NotEqual(t, dep.Source.Oci, nil)
@@ -201,6 +202,43 @@ func TestDownloadOci(t *testing.T) {
 	assert.Equal(t, dep.Source.Oci.Repo, filepath.Join(settings.DEFAULT_REPO, "k8s"))
 	assert.Equal(t, dep.Source.Oci.Tag, "1.27.2")
 	assert.Equal(t, dep.LocalFullPath, testPath)
+	assert.Equal(t, err, nil)
+
+	// Check whether the tar downloaded by `kpm add` has been deleted.
+	assert.Equal(t, utils.DirExists(filepath.Join(testPath, "k8s_1.27.2.tar")), false)
+
+	err = os.RemoveAll(getTestDir("download"))
+	assert.Equal(t, err, nil)
+}
+
+// TestDownloadLatestOci tests the case that the version is empty.
+func TestDownloadLatestOci(t *testing.T) {
+	testPath := filepath.Join(getTestDir("download"), "a_random_name")
+	err := os.MkdirAll(testPath, 0755)
+	assert.Equal(t, err, nil)
+
+	depFromOci := Dependency{
+		Name:    "k8s",
+		Version: "",
+		Source: Source{
+			Oci: &Oci{
+				Reg:  settings.DEFAULT_REGISTRY,
+				Repo: filepath.Join(settings.DEFAULT_REPO, "k8s"),
+				Tag:  "",
+			},
+		},
+	}
+
+	dep, err := depFromOci.Download(testPath)
+	assert.Equal(t, dep.Name, "k8s")
+	assert.Equal(t, dep.FullName, "k8s_1.27.2")
+	assert.Equal(t, dep.Version, "1.27.2")
+	assert.Equal(t, dep.Sum, "ZI7L/uz53aDOIgVgxBbEPG7wGCWR+Gd3hhgYYRLoIY4=")
+	assert.NotEqual(t, dep.Source.Oci, nil)
+	assert.Equal(t, dep.Source.Oci.Reg, settings.DEFAULT_REGISTRY)
+	assert.Equal(t, dep.Source.Oci.Repo, filepath.Join(settings.DEFAULT_REPO, "k8s"))
+	assert.Equal(t, dep.Source.Oci.Tag, "1.27.2")
+	assert.Equal(t, dep.LocalFullPath, testPath+"1.27.2")
 	assert.Equal(t, err, nil)
 
 	// Check whether the tar downloaded by `kpm add` has been deleted.

--- a/pkg/package/package.go
+++ b/pkg/package/package.go
@@ -373,7 +373,7 @@ func getDeps(deps modfile.Dependencies, lockDeps modfile.Dependencies, localPath
 	// Recursively download the dependencies of the new dependencies.
 	for _, d := range newDeps.Deps {
 		// Load kcl.mod file of the new downloaded dependencies.
-		modfile, err := modfile.LoadModFile(filepath.Join(localPath, d.FullName))
+		modfile, err := modfile.LoadModFile(d.LocalFullPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix issue #98 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

kpm add

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

If the `kpm add` command does not contain the tag information, the path where the package is saved loses the tag information.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
